### PR TITLE
chore(.github): comment analyze conditional

### DIFF
--- a/.github/workflows/fossa.yaml
+++ b/.github/workflows/fossa.yaml
@@ -120,7 +120,7 @@ jobs:
       - name: Analyze
         env:
           FOSSA_API_KEY: ${{ secrets.fossa-api-key }}
-        if: ${{ fromJSON(steps.list-targets.outputs.targets_count) > 0 }}
+        # if: ${{ fromJSON(steps.list-targets.outputs.targets_count) > 0 }}
         run: |
           fossa analyze
 


### PR DESCRIPTION
When `list-targets` is run and 0 deps are discovered, the analyze step is skipped which results in the repo not reporting to FOSSA.  There should be no issue in removing this conditional as FOSSA will just report 0 issues and the repo will at least show up in the UI.